### PR TITLE
Slightly improve errors when a resource fails to start because a depe…

### DIFF
--- a/WaitForDependencies.Aspire.Hosting/WaitForDependenciesExtensions.cs
+++ b/WaitForDependencies.Aspire.Hosting/WaitForDependenciesExtensions.cs
@@ -171,7 +171,7 @@ public static class WaitForDependenciesExtensions
                                {
                                    pendingAnnotations.TryRemove(waitOn, out _);
 
-                                   tcs.TrySetCanceled();
+                                   tcs.TrySetException(new Exception($"Dependency {waitOn.Resource.Name} failed to start"));
                                }
                            }
                        }


### PR DESCRIPTION
When a resource has `WaitFor`, and the dependency being waited on failed to star tup, it's not immediately clear int eh console logs why the later service failed to start - it just show `TaskCanceledException`.

This changes the cancellation to an exception who's text slightly states the dependency that failed.

There's probably many more UX improvements that can be made here, but this is a quick win that provides some improvement.