### PR TITLE
Add waiting status to resources that are waiting for start up

### DIFF
--- a/WaitForDependencies.Aspire.Hosting/WaitForDependenciesExtensions.cs
+++ b/WaitForDependencies.Aspire.Hosting/WaitForDependenciesExtensions.cs
@@ -123,6 +123,11 @@ public static class WaitForDependenciesExtensions
                         }
                     }
 
+                    await resourceNotificationService.PublishUpdateAsync(r, s => s with
+                    {
+                        State = new("Waiting", KnownResourceStateStyles.Info)
+                    });
+                    
                     await Task.WhenAll(dependencies).WaitAsync(context.CancellationToken);
                 }));
             }


### PR DESCRIPTION
Add a `Waiting` status to make clear which resources are waiting for others to start
![image](https://github.com/davidfowl/WaitForDependenciesAspire/assets/289860/cc9ff9dd-1dcf-4169-a2f5-38bca51f938a)

I would have liked to use the dashed circle used for the initial starting state, however it looks like that state is special cased in the dashboard code
![image](https://github.com/davidfowl/WaitForDependenciesAspire/assets/289860/eeb4c68c-67aa-41eb-b4f5-517e725955c9)
https://github.com/dotnet/aspire/blob/f762d505df5947b8b9a7ce145a7ebc548616a521/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor#L27-L32

There's also an issue when the resource transition from `Waiting` --> `Started` as the UI briefly flashes to `Unknown` for a second or so before going to `Started`.