### PR TITLE
Add example unit test project that shares the DistributedApp Instance across all tests.

### DIFF
--- a/TestExample/Support/AspireAppHostFixture.cs
+++ b/TestExample/Support/AspireAppHostFixture.cs
@@ -13,9 +13,5 @@ public class AspireAppHostFixture : IAsyncLifetime
         await DistributedApplicationInstance.StartAsync();
     }
     
-    public async Task DisposeAsync()
-    {
-        await DistributedApplicationInstance.StopAsync();
-        await DistributedApplicationInstance.DisposeAsync();
-    }
+    public Task DisposeAsync() => DistributedApplicationInstance.DisposeAsync().AsTask();
 }

--- a/TestExample/Support/AspireAppHostFixture.cs
+++ b/TestExample/Support/AspireAppHostFixture.cs
@@ -1,0 +1,21 @@
+using Projects;
+
+namespace TestExample.Support;
+
+public class AspireAppHostFixture : IAsyncLifetime
+{
+    public DistributedApplication DistributedApplicationInstance { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<WaitForDependencies_AppHost>();
+        DistributedApplicationInstance = await appHost.BuildAsync();
+        await DistributedApplicationInstance.StartAsync();
+    }
+    
+    public async Task DisposeAsync()
+    {
+        await DistributedApplicationInstance.StopAsync();
+        await DistributedApplicationInstance.DisposeAsync();
+    }
+}

--- a/TestExample/Support/AspireFixtureCollection.cs
+++ b/TestExample/Support/AspireFixtureCollection.cs
@@ -1,0 +1,9 @@
+namespace TestExample.Support;
+
+[CollectionDefinition(nameof(AspireFixtureCollection))]
+public class AspireFixtureCollection : ICollectionFixture<AspireAppHostFixture>
+{
+    // This class has no code, and is never created. Its purpose is simply
+    // to be the place to apply [CollectionDefinition] and all the
+    // ICollectionFixture<> interfaces.
+}

--- a/TestExample/TestExample.csproj
+++ b/TestExample/TestExample.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Testing" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Aspire.Hosting.Testing" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WaitForDependencies.AppHost\WaitForDependencies.AppHost.csproj" />
+    <ProjectReference Include="..\WebApplication1\WebApplication1.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestExample/Tests/ApiExampleTests.cs
+++ b/TestExample/Tests/ApiExampleTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using TestExample.Support;
+
+namespace TestExample.Tests;
+
+[Collection(nameof(AspireFixtureCollection))]
+public class ApiExampleTests(AspireAppHostFixture fixture)
+{
+    private readonly DistributedApplication _distributedApplication = fixture.DistributedApplicationInstance;
+    
+    [Fact]
+    public async Task ProductsApi_GetProducts_ReturnsAtLeastOne()
+    {
+        using var httpClient = _distributedApplication.CreateHttpClient("api");
+        var response = await httpClient.GetAsync("/");
+        
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<List<Product>>();
+        
+        body.Should().NotBeNullOrEmpty();
+        body!.Count.Should().BeGreaterThan(0);
+    }
+    
+    [Fact]
+    public async Task GenericApi_GetIndex_ReturnsHelloWorld()
+    {
+        using var httpClient = _distributedApplication.CreateHttpClient("api0");
+        var response = await httpClient.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        
+        body.Should().Be("Hello World!");
+    }
+}

--- a/WaitForDependenciesDemo.sln
+++ b/WaitForDependenciesDemo.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApplication2", "WebAppli
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceDefaults1", "ServiceDefaults1\ServiceDefaults1.csproj", "{AF8A1424-3A45-4148-B652-653465DD0D78}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestExample", "TestExample\TestExample.csproj", "{5B22E61C-FE81-4B3F-80CF-0A200A9DCADE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{AF8A1424-3A45-4148-B652-653465DD0D78}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF8A1424-3A45-4148-B652-653465DD0D78}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF8A1424-3A45-4148-B652-653465DD0D78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B22E61C-FE81-4B3F-80CF-0A200A9DCADE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B22E61C-FE81-4B3F-80CF-0A200A9DCADE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B22E61C-FE81-4B3F-80CF-0A200A9DCADE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B22E61C-FE81-4B3F-80CF-0A200A9DCADE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WebApplication1/Program.cs
+++ b/WebApplication1/Program.cs
@@ -24,7 +24,7 @@ class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
     public DbSet<Product> Products { get; set; }
 }
 
-class Product 
+internal class Product 
 {
     public int Id { get; set; }
     public string Name { get; set; } = default!;

--- a/WebApplication1/WebApplication1.csproj
+++ b/WebApplication1/WebApplication1.csproj
@@ -10,5 +10,9 @@
     <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-preview.6.24214.1" />
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.6.24214.1" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <InternalsVisibleTo Include="TestExample" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Internally I've had a few people ask me how to do this, and not instantiate the AppHost for every test, so showing a simple example of using a fixture collection.
